### PR TITLE
Revert "Add master_url env var to void relying on oauth_authorize_uri…

### DIFF
--- a/osconsole/config.js.tmpl
+++ b/osconsole/config.js.tmpl
@@ -2,7 +2,6 @@ window.OPENSHIFT_CONFIG = {
   auth: {
     oauth_authorize_uri: "{{ .Env.OAUTH_AUTHORIZE_URI }}",
     oauth_client_id: "{{ .Env.OAUTH_CLIENT_ID }}",
-    master_uri: "{{ .Env.KUBERNETES_MASTER }}",
     logout_uri: "",
     clientId: "{{ .Env.GOOGLE_OAUTH_CLIENT_ID }}",
     clientSecret: "{{ .Env.GOOGLE_OAUTH_CLIENT_SECRET }}",


### PR DESCRIPTION
… to work out the master"

This reverts commit e194acbcc619bca562a4a8f3e051a3c581c02c4c.

This prevents hawtio-kubernetes from working out the master_uri from the oauth_authorize_uri env var.